### PR TITLE
Updated Gulpfile error handler to emit so watch task doesn't stop

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -90,6 +90,7 @@ function errorHandler(err){
 	if (showErrorStack) {
 		gutil.log(err.stack);
 	}
+	this.emit('end');
 }
 
 // CSS / Sass compilation


### PR DESCRIPTION
Updated Gulpfile error handler to `emit('end')` so that watch task doesn't stop on errors.
